### PR TITLE
Fix duplicate import in __init__ file

### DIFF
--- a/obsidian_analyzer/__init__.py
+++ b/obsidian_analyzer/__init__.py
@@ -6,6 +6,5 @@ from .multi_analyzer import MultiVaultAnalyzer, VaultAnalysis, FolderStats
 
 __version__ = "0.1.0"
 from .safe_auto_linker import SafeAutoLinker, SafetyLevel
-from .safe_auto_linker import SafeAutoLinker, SafetyLevel
 from .ai_semantic_linker import AISemanticLinker, SemanticConnection
 from .content_gap_analyzer import ContentGapAnalyzer, ContentGap, KnowledgeCluster


### PR DESCRIPTION
## Summary
- remove duplicate `SafeAutoLinker` import from `obsidian_analyzer/__init__.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*