### PR TITLE
Fix custom folder handling in AutoLinker

### DIFF
--- a/obsidian_analyzer/auto_linker.py
+++ b/obsidian_analyzer/auto_linker.py
@@ -48,6 +48,7 @@ class AutoLinker:
     def analyze_and_suggest_links(self, folder_name: str = "Coding") -> Dict[str, List[LinkSuggestion]]:
         """Analyze folder and get link suggestions for all notes."""
         analyzer = CodingFolderAnalyzer(self.vault_path)
+        analyzer.coding_folder = self.vault_path / folder_name
         analyzer.load_coding_notes()
         
         if not analyzer.notes:


### PR DESCRIPTION
## Summary
- ensure `analyze_and_suggest_links` sets the analyzer's folder before loading notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*