### PR TITLE
Fix folder selection in AutoLinker

### DIFF
--- a/obsidian_analyzer/__init__.py
+++ b/obsidian_analyzer/__init__.py
@@ -6,6 +6,16 @@ from .multi_analyzer import MultiVaultAnalyzer, VaultAnalysis, FolderStats
 
 __version__ = "0.1.0"
 from .safe_auto_linker import SafeAutoLinker, SafetyLevel
-from .safe_auto_linker import SafeAutoLinker, SafetyLevel
-from .ai_semantic_linker import AISemanticLinker, SemanticConnection
-from .content_gap_analyzer import ContentGapAnalyzer, ContentGap, KnowledgeCluster
+
+try:
+    from .ai_semantic_linker import AISemanticLinker, SemanticConnection
+except Exception:  # pragma: no cover - optional dependency may not be installed
+    AISemanticLinker = None
+    SemanticConnection = None
+
+try:
+    from .content_gap_analyzer import ContentGapAnalyzer, ContentGap, KnowledgeCluster
+except Exception:  # pragma: no cover - optional dependency may not be installed
+    ContentGapAnalyzer = None
+    ContentGap = None
+    KnowledgeCluster = None

--- a/obsidian_analyzer/auto_linker.py
+++ b/obsidian_analyzer/auto_linker.py
@@ -46,8 +46,9 @@ class AutoLinker:
         shutil.copy2(file_path, backup_file)
     
     def analyze_and_suggest_links(self, folder_name: str = "Coding") -> Dict[str, List[LinkSuggestion]]:
-        """Analyze folder and get link suggestions for all notes."""
+        """Analyze a folder and get link suggestions for all notes."""
         analyzer = CodingFolderAnalyzer(self.vault_path)
+        analyzer.coding_folder = self.vault_path / folder_name
         analyzer.load_coding_notes()
         
         if not analyzer.notes:

--- a/tests/unit/test_auto_linker.py
+++ b/tests/unit/test_auto_linker.py
@@ -58,3 +58,18 @@ Another target note.
         note1_path = Path(test_vault_path) / "Coding" / "note1.md"
         content = note1_path.read_text()
         assert "[[note2]]" not in content  # Should not be modified in dry run
+
+    def test_analyze_custom_folder(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            vault_path = Path(temp_dir)
+            docs_folder = vault_path / "Docs"
+            docs_folder.mkdir()
+
+            (docs_folder / "a.md").write_text("This mentions b note.")
+            (docs_folder / "b.md").write_text("B note content")
+
+            linker = AutoLinker(str(vault_path), backup=False)
+            suggestions = linker.analyze_and_suggest_links("Docs")
+
+            assert suggestions
+            assert "a" in suggestions


### PR DESCRIPTION
## Summary
- ensure `AutoLinker.analyze_and_suggest_links` respects the folder argument
- avoid mandatory imports of optional AI modules
- add unit test covering custom folder analysis

## Testing
- `pytest tests/unit/test_auto_linker.py -q`
