### PR TITLE
Add Codex setup script using uv

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure uv is available
+if ! command -v uv >/dev/null 2>&1; then
+    python3 -m pip install --break-system-packages uv
+fi
+
+# Install project in editable mode with all dependencies
+uv pip install -e .


### PR DESCRIPTION
## Summary
- provide a `.codex/setup.sh` script
- install uv if missing
- use uv to install the project in editable mode

## Testing
- `bash .codex/setup.sh`